### PR TITLE
Add a default value to library

### DIFF
--- a/lua/AutoConfig.lua
+++ b/lua/AutoConfig.lua
@@ -1,5 +1,5 @@
 ---@class Library
-local library = DULibrary
+local library = DULibrary or {}
 
 --- Returns a list of elements linked to the current Control Unit
 ---@param filters table<string, string> A list of filters where each key is a element function and the value is the desired value


### PR DESCRIPTION
 If case DULibrary is not loaded (mainly when executing code ouside DU), we get an error because of it.