### PR TITLE
Add support for using callable objects as event handlers.

### DIFF
--- a/lua/Events.lua
+++ b/lua/Events.lua
@@ -32,12 +32,12 @@ function library.addEventHandlers(obj)
 
     if 'table' == type(handler) then
       -- We got a table, check if it is callable
-      local originalHander = handler
       local mt = getmetatable(handler)
-      if mt.__call then
-        -- The table is a callable, redefine the handler to call the object via its metatable
+      if mt and mt.__call then
+        local originalHander = handler
+        -- The table is a callable, redefine the handler to call the object
         handler = function(s, ...)
-          mt.__call(originalHander, s, ...)
+          originalHander(s, ...)
         end
       else
         signalHandlerError(handler)


### PR DESCRIPTION
Hi!

I've started using Busted as test framework. One of it great features is the ability to mock/spy on functions and tables to ensure correct call chains and values. To accomplish that magic, Busted replaces the contents of the original table with wrappers that are all tables. So, when passing these to onEvent added by LuaC, it receives a (callable) table instead of a function, which it in its current version does not support.

This PR changes the onEvent handler to support callable tables. You can view an example of the usage in this test: https://github.com/PerMalmberg/du-unit-testing/blob/main/src/setup_mocks_spec.lua#L23 (this repo isn't ready for use yet as it requires four PRs to NQ's lua-example repo to fix compile errors)

Talking of test, I don't see any tests for LuaC, let me know if there are any and I'll add test cases for this addition.